### PR TITLE
Remove brackets from virtual filename `Display` impl

### DIFF
--- a/diagnostics/src/filename.rs
+++ b/diagnostics/src/filename.rs
@@ -110,7 +110,7 @@ impl fmt::Display for FileName {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             FileName::Real(ref path) => write!(fmt, "{}", path.display()),
-            FileName::Virtual(ref name) => write!(fmt, "<{}>", name),
+            FileName::Virtual(ref name) => write!(fmt, "{}", name),
         }
     }
 }


### PR DESCRIPTION
Discovered in https://github.com/0xPolygonMiden/compiler/pull/220

This PR removes the brackets enclosing in `Display` impl for `FileName` to be in sync with `as_str` implementation and to avoid generating invalid MASM module ids (brackets are not allowed).

